### PR TITLE
typo: markdown link

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -56,7 +56,7 @@ USE THIS MODULE TO LOAD ALL YOUR CONFIGURATIONS
 
 FINALLY, EASY FLEXIBLE CONFIGURATIONS!
 
-##see also: (proto-list)[https://github.com/isaacs/proto-list/]
+##see also: [proto-list](https://github.com/isaacs/proto-list/)
 
 WHATS THAT YOU SAY?
 


### PR DESCRIPTION
this used to trip me up every time I went to do a markdown link. Poor choice of syntax elements imo. The mnemonic I use to remember this is the edges of the square bracket look like they're partially underlining the item, like a hyperlink underline.
