### PR TITLE
Remove unused global variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,7 @@ var env = exports.env = function (prefix, env) {
   var obj = {}
   var l = prefix.length
   for(var k in env) {
-    if((i =k.indexOf(prefix)) === 0)
+    if(k.indexOf(prefix) === 0)
       obj[k.substring(l)] = env[k]
   }
 


### PR DESCRIPTION
The mocha test framework detected a global leak (I'm using dominictarr/rc in a project).

This just removes the unused variable.
