### PR TITLE
Make cc.find work on windows 

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var find = exports.find = function () {
       fs.statSync(file)
       return file
     } catch (err) {
-      if(start != '/')
+      if(path.dirname(start) == start) // root
         return find(path.dirname(start), rel)
     }
   }


### PR DESCRIPTION
cc.find would give a stack overflow on windows, since it doesn't recognize windows root directories.
This should be fixed, now.
