### PR TITLE
find: Start from process.cwd() instead of __dirname.

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ var find = exports.find = function () {
         return find(path.dirname(start), rel)
     }
   }
-  return find(__dirname, rel)
+  return find(process.cwd(), rel)
 }
 
 var parse = exports.parse = function (content, file, type) {


### PR DESCRIPTION
This supports a globally-installed dependency on config-chain being able to traverse a more sensible directory tree, instead of /usr/local/*. This makes the `cc.find(".myconfigrc")` result more consistent with expectations when run by a global utility.

https://github.com/einars/js-beautify/issues/228 demonstrates this problem.
