### PR TITLE
Allow for comment ins JSON files

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var ProtoList = require('proto-list')
   , EE = require('events').EventEmitter
   , url = require('url')
   , http = require('http')
+  , stripJsonComments = require('strip-json-comments');
 
 var exports = module.exports = function () {
   var args = [].slice.call(arguments)
@@ -39,6 +40,10 @@ var find = exports.find = function () {
   return find(__dirname, rel)
 }
 
+function parseJson(content) {
+    return JSON.parse(stripJsonComments(content));
+}
+
 var parse = exports.parse = function (content, file, type) {
   content = '' + content
   // if we don't know what it is, try json and fall back to ini
@@ -48,10 +53,10 @@ var parse = exports.parse = function (content, file, type) {
     catch (er) { return ini.parse(content) }
   } else if (type === 'json') {
     if (this.emit) {
-      try { return JSON.parse(content) }
+      try { return parseJson(content) }
       catch (er) { this.emit('error', er) }
     } else {
-      return JSON.parse(content)
+      return parseJson(content);
     }
   } else {
     return ini.parse(content)

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "proto-list": "~1.2.1",
-    "ini": "1"
+    "ini": "1",
+    "strip-json-comments": "~0.1.1"
   },
   "devDependencies": {
     "tap": "0.4.8"

--- a/test/comments.js
+++ b/test/comments.js
@@ -1,0 +1,11 @@
+
+
+var cc = require('..')
+var assert = require('assert')
+
+
+assert.deepEqual(
+    {hello: 'world'},
+    cc(__dirname + '/comments.json').get('one')
+);
+

--- a/test/comments.json
+++ b/test/comments.json
@@ -1,0 +1,9 @@
+{
+    // Awesome comments
+    "one": {
+        /*
+         * More comments
+         */
+        "hello": "world"
+    }
+}


### PR DESCRIPTION
This allows to use comments in JSON files. The main reason is ini files don't provide correct handling of numbers so we needed to use JSON but couldn't add comments. Now this is possible:

``` js
{
     // Awesome comments
     "one": {
         /*
          * More comments
          */
         "hello": "world"
     }
 }
```
