### PR TITLE
Avoid pushing undefined into proto-list

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,11 @@ var exports = module.exports = function () {
 
   while(args.length) {
     var a = args.shift()
-    if(a) conf.push
-          ( 'string' === typeof a
-            ? json(a)
-            : a )
+    if(a) {
+      var obj = 'string' === typeof a ? json(a) : a
+      
+      if (obj) conf.push(obj)
+    }
   }
 
   return conf

--- a/package.json
+++ b/package.json
@@ -16,6 +16,6 @@
   },
   "author": "Dominic Tarr <dominic.tarr@gmail.com> (http://dominictarr.com)",
   "scripts": {
-    "test": "tap test/"
+    "test": "tap test/*.js"
   }
 }

--- a/test/save.js
+++ b/test/save.js
@@ -38,7 +38,7 @@ test('test saving and loading ini files', function (t) {
         .save('jsonfile')
         .on('save', function () {
           t.equal(fs.readFileSync(f1, 'utf8'),
-                  "bloo = jaus\nfoo = zoo\n")
+                  "bloo=jaus\nfoo=zoo\n")
           t.equal(fs.readFileSync(f2, 'utf8'),
                   "{\"oof\":\"ooz\",\"oolb\":\"suaj\"}")
 


### PR DESCRIPTION
If `json(a)` returns undefined we push undefined into proto-list.

Proto-list gets confused and inserts a weird object into the
proto list tree.

We should avoid pushing anything if `json()` returns nothing.

cc @dominictarr @isaacs 
